### PR TITLE
fix file naming, add software versions to metadata

### DIFF
--- a/asard/ancillary.py
+++ b/asard/ancillary.py
@@ -1,30 +1,29 @@
 import os
 import sys
 import logging
+from typing import Any
 from datetime import datetime
-from importlib import import_module
-from osgeo import gdal
-import spatialist
-import pyroSAR
-import asard
+from asard.config import version_dict
 
 log = logging.getLogger('asard')
 
 
-def set_logging(config, debug=False):
+def set_logging(
+        config: dict[str, Any],
+        debug: bool = False
+) -> logging.Logger:
     """
     Set logging for the current process.
 
     Parameters
     ----------
-    config: dict
+    config:
         Dictionary of the parsed config parameters for the current process.
-    debug: bool
+    debug:
         Set logging level to DEBUG?
 
     Returns
     -------
-    logging.Logger
         The log handler for the current process.
     """
     level = logging.DEBUG if debug else logging.INFO
@@ -65,28 +64,24 @@ def set_logging(config, debug=False):
     return logger
 
 
-def _log_process_config(logger, config):
+def _log_process_config(
+        logger: logging.Logger,
+        config: dict[str, Any]
+) -> None:
     """
     Adds a header to the logfile, which includes information about
     the current processing configuration.
 
     Parameters
     ----------
-    logger: logging.Logger
+    logger:
         The logger to which the header is added to.
-    config: dict
+    config:
         Dictionary of the parsed config parameters for the current process.
     """
-    sw_versions = {
-        'asard': asard.__version__,
-        'python': sys.version,
-        'python-pyroSAR': pyroSAR.__version__,
-        'python-spatialist': spatialist.__version__,
-        'python-GDAL': gdal.__version__}
-    
     processor_name = config['processing']['processor']
-    processor = import_module(f'asard.{processor_name}')
-    sw_versions.update(processor.version_dict())
+    
+    sw_versions = version_dict(processor_name=processor_name)
     
     max_len_sw = len(max(sw_versions.keys(), key=len))
     max_len_main = len(max(config['processing'].keys(), key=len))

--- a/asard/ard.py
+++ b/asard/ard.py
@@ -564,7 +564,7 @@ def product_info(product_type, src_ids, tile_id, extent, epsg,
     skeleton_dir = ('{mission}{sensor}{mode}{product_type}_{start}_{duration:04}__'
                     '{orbitnumber_rel:03X}_S{id}_{phase}{cycle:03}_{polarization:_>4}_{tile}')
     skeleton_files = ('{mission}{sensor}{mode}{product_type}-{start}-{duration:04}--'
-                      '{orbitnumber_rel:03x}-s{id}-{phase}{cycle:03}-{polarization:_>4}-{tile}')
+                      '{orbitnumber_rel:03x}-s{id}-{phase}{cycle:03}-{polarization:->4}-{tile}')
     
     meta['product_base'] = skeleton_dir.format(**meta_name)
     meta['dir_ard'] = os.path.join(dir_out, meta['product_base'])

--- a/asard/config.py
+++ b/asard/config.py
@@ -6,7 +6,8 @@ import configparser
 from datetime import timedelta
 from dateutil.parser import parse as dateparse
 from osgeo import gdal
-from cesard.config import keyval_check, validate_options, validate_value
+from cesard.config import (keyval_check, validate_options, validate_value,
+                           version_dict as cesard_version_dict)
 
 
 def get_keys(section):
@@ -259,3 +260,25 @@ def gdal_conf(config):
     
     return {'threads': threads, 'threads_before': threads_before,
             'multithread': multithread}
+
+
+def version_dict(processor_name: str) -> dict[str, str]:
+    """
+    Get the versions of used packages
+
+    Parameters
+    ----------
+    processor_name:
+        the name of the used SAR processor (e.g. `snap`)
+    
+    Returns
+    -------
+        a dictionary containing the versions of relevant python packages and
+        the return of the `version_dict` function of the used SAR processor.
+    """
+    import asard
+    out = cesard_version_dict()
+    out['asard'] = asard.__version__
+    processor = import_module(f'asard.{processor_name}')
+    out.update(processor.version_dict())
+    return out

--- a/asard/metadata/extract.py
+++ b/asard/metadata/extract.py
@@ -4,12 +4,14 @@ from spatialist import Raster
 from spatialist.ancillary import finder
 from spatialist.raster import rasterize
 
-import asard
 from asard import snap
+from asard.config import version_dict
 from asard.metadata.mapping import ORB_MAP, NOISE_MAP, URL
 
 from cesard.metadata.mapping import DEM_MAP, LERC_ERR_THRES
-from cesard.metadata.extract import calc_enl, geometry_from_vec, calc_performance_estimates, vec_from_srccoords
+from cesard.metadata.extract import (calc_enl, geometry_from_vec,
+                                     calc_performance_estimates,
+                                     vec_from_srccoords)
 
 
 def get_prod_meta(tif, src_ids, sar_dir):
@@ -212,7 +214,8 @@ def meta_dict(config, prod_meta, src_ids, compression):
     meta['prod']['processingLevel'] = 'Level 2'
     meta['prod']['processingMode'] = 'PROTOTYPE'
     meta['prod']['processorName'] = 'asard'
-    meta['prod']['processorVersion'] = asard.__version__
+    sw_versions = version_dict(processor_name=config['processing']['processor'])
+    meta['prod']['processorVersion'] = sw_versions
     meta['prod']['productName'] = 'Normalised Radar Backscatter'
     meta['prod']['productName-short'] = 'NRB'
     meta['prod']['pxSpacingColumn'] = str(prod_meta['res'][0])
@@ -281,7 +284,7 @@ def meta_dict(config, prod_meta, src_ids, compression):
         try:
             proc_name, proc_version = src_sid[uid].meta['origin']['MPH']['SOFTWARE_VER'].split('/')
             meta['source'][uid]['processorName'] = proc_name
-            meta['source'][uid]['processorVersion'] = proc_version
+            meta['source'][uid]['processorVersion'] = {proc_name: proc_version}
         except:
             meta['source'][uid]['processorName'] = None
             meta['source'][uid]['processorVersion'] = None

--- a/asard/metadata/extract.py
+++ b/asard/metadata/extract.py
@@ -1,4 +1,3 @@
-import os
 import numpy as np
 from dateutil.parser import parse as dateparse
 from spatialist import Raster
@@ -7,9 +6,9 @@ from spatialist.raster import rasterize
 
 import asard
 from asard import snap
-from asard.metadata.mapping import ORB_MAP, NOISE_MAP, URL as URL_PACKAGE
+from asard.metadata.mapping import ORB_MAP, NOISE_MAP, URL
 
-from cesard.metadata.mapping import DEM_MAP, URL as URL_BASE, LERC_ERR_THRES
+from cesard.metadata.mapping import DEM_MAP, LERC_ERR_THRES
 from cesard.metadata.extract import calc_enl, geometry_from_vec, calc_performance_estimates, vec_from_srccoords
 
 
@@ -89,9 +88,6 @@ def meta_dict(config, prod_meta, src_ids, compression):
     
     dummy_num = -99999
     dummy_str = 'TBD'
-    
-    URL = URL_BASE
-    URL.update(URL_PACKAGE)
     
     meta = {'prod': {},
             'source': {},

--- a/asard/metadata/mapping.py
+++ b/asard/metadata/mapping.py
@@ -1,3 +1,5 @@
+from cesard.metadata.mapping import URL
+
 ARD_PATTERN = r'^(?P<mission>ER[12]|ENV)' \
               r'(?P<sensor>A|S)' \
               r'(?P<mode>IM|AP|WS)' \
@@ -72,14 +74,10 @@ SAMPLE_MAP = {
                 'title': 'Acquisition ID Image'}
 }
 
-URL = {
-    'ancillaryData_KML': 'https://sentiwiki.copernicus.eu/__attachments/1692737/'
-                         'S2A_OPER_GIP_TILPAR_MPC__20151209T095117_V20150622T000000_21000101T000000_B00.zip',
-    'card4l_nrb': 'https://ceos.org/ard/files/PFS/NRB/v5.5/CARD4L-PFS_NRB_v5.5.pdf',
+URL.update({
     'faradayRotationReference': None,
     'geoCorrAccuracyReference': None,
     'geoCorrAlgorithm': 'TBD',
-    'griddingConventionURL': 'https://www.mgrs-data.org/data/documents/nga_mgrs_doc.pdf',
     'noiseRemovalAlgorithm': 'TBD',
     'orbitDataAccess': 'TBD',
     'radiometricAccuracyReference': None,
@@ -87,4 +85,4 @@ URL = {
     'sensorCalibration': None,
     'source_access': 'https://esar-ds.eo.esa.int',
     'source_doi': None
-}
+})

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -17,6 +17,7 @@ Configuration
         get_config
         get_keys
         read_config_file
+        version_dict
 
 Processing
 ----------

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,7 +2,7 @@ name: asard_dev
 channels:
   - conda-forge
 dependencies:
-  - cesard>=1.0.1
+  - cesard>=1.1.1
   - click>=7.1.0
   - gdal>=3.5.0
   - numpy

--- a/environment.yaml
+++ b/environment.yaml
@@ -2,7 +2,7 @@ name: asard
 channels:
   - conda-forge
 dependencies:
-  - cesard>=1.0.1
+  - cesard>=1.1.1
   - click>=7.1.0
   - gdal>=3.5.0
   - numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cesard>=1.0.1
+cesard>=1.1.1
 click>=7.1.0
 gdal>=3.5.0
 numpy<2.0


### PR DESCRIPTION
The polarization in the file name was accidentally filled with `_` instead of `-`.  
Also, software versions are now centrally handled in `asard.config.version_dict` and written to the STAC metadata.